### PR TITLE
Change internal handling of include-*-list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX=g++
 TARGET_GCC=gcc
 PLUGIN_NAME= instrument_attribute
-PLUGIN_SOURCE_FILES= $(PLUGIN_NAME).cpp
+PLUGIN_SOURCE_FILES= $(PLUGIN_NAME).c
 TEST_SOURCE_FILES= test/test.c test/other/other_file.h
 GCCPLUGINS_DIR:= $(shell $(TARGET_GCC) -print-file-name=plugin)
 CXXFLAGS+= -I$(GCCPLUGINS_DIR)/include -fPIC -O2


### PR DESCRIPTION
We were re-splitting the list strings (include-file-list and include-function-list) for every given function in order to check whether it matches something in the list. Unfortunately, `strtok_r` "modifies" the string it is given, so it was pretty much invalidated after the first check. I think this explains #12.

Now we're splitting the list strings only once, at the beginning, and reusing it afterwards. I had to do some memory allocations, but it's only done once at startup and only depends on the CLI args, so it should be very reasonable.

This also reverts #14

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>