### PR TITLE
Add end-to-end tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
         sudo apt-get update && sudo apt-get install -q -y ${{ matrix.gcc }} ${{ matrix.gxx }} ${{ matrix.gcc }}-plugin-dev
         ${{ matrix.gcc }} --version
         ${{ matrix.gxx }} --version
+    - name: Install test dependencies
+      run: |
+        sudo apt-get install -q -y lttng-tools liblttng-ust-dev babeltrace
+        lttng --version
+        babeltrace
     - name: Build
       run: |
         make TARGET_GCC=${{ matrix.gcc }} CXX=${{ matrix.gxx }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,13 @@
 # executables
 verify
-test/test
+test/test_end-to-end
 test/test_utils
-
 # directories
-.vscode/
 test-trace/
+test/e2e/trace/
+
+# IDE
+.vscode/
 
 # Prerequisites
 *.d

--- a/license-mit.txt
+++ b/license-mit.txt
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2020 Christophe Bedard
+Copyright (c) 2019-2021 Christophe Bedard
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/test/e2e/include/a_header.h
+++ b/test/e2e/include/a_header.h
@@ -1,0 +1,25 @@
+// Copyright (c) 2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+void myawesomelib_function_a();
+
+void myawesomelib_function_b();
+
+void mynotawesomelib_function_c();

--- a/test/e2e/include/other/other_file.h
+++ b/test/e2e/include/other/other_file.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Christophe Bedard
+// Copyright (c) 2019-2021 Christophe Bedard
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -20,7 +20,9 @@
 
 #include <stdio.h>
 
-void instrumented_with_file_list()
+void other_file_instrumented_with_file_list()
 {
-  printf("this can be instrumented via include-file-list\n");
+  // Using a path to the header file since
+  // that's the file that contains the implementation
+  printf("instrumented via include-file-list\n");
 }

--- a/test/e2e/include/some_dir/some_header.h
+++ b/test/e2e/include/some_dir/some_header.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+void some_header_instrumented_with_file_list();

--- a/test/e2e/include/some_dir/some_other_header.h
+++ b/test/e2e/include/some_dir/some_other_header.h
@@ -1,0 +1,21 @@
+// Copyright (c) 2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+void __attribute__((instrument_function)) some_other_header_instrumented_with_file_list_and_attribute();

--- a/test/e2e/src/a_file.c
+++ b/test/e2e/src/a_file.c
@@ -1,0 +1,38 @@
+// Copyright (c) 2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdio.h>
+
+#include "a_header.h"
+
+void myawesomelib_function_a()
+{
+  printf("instrumented via include-function-list with 'myawesomelib_' prefix\n");
+}
+
+void myawesomelib_function_b()
+{
+  printf("instrumented via include-function-list with 'myawesomelib_' prefix\n");
+}
+
+void mynotawesomelib_function_c()
+{
+  printf("not instrumented\n");
+}

--- a/test/e2e/src/main.c
+++ b/test/e2e/src/main.c
@@ -1,0 +1,60 @@
+// Copyright (c) 2019-2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdio.h>
+
+#include "a_header.h"
+#include "other/other_file.h"
+#include "some_dir/some_header.h"
+#include "some_dir/some_other_header.h"
+
+void __attribute__((instrument_function)) instrumented_function()
+{
+  printf("instrumented with attribute\n");
+}
+
+void not_instrumented_function()
+{
+  printf("not instrumented\n");
+}
+
+void instrumented_with_function_list()
+{
+  printf("instrumented via include-function-list\n");
+}
+
+int __attribute__((instrument_function)) main()
+{
+  printf("instrumented with attribute\n");
+
+  instrumented_function();
+  not_instrumented_function();
+  instrumented_with_function_list();
+
+  other_file_instrumented_with_file_list();
+
+  some_header_instrumented_with_file_list();
+  some_other_header_instrumented_with_file_list_and_attribute();
+
+  myawesomelib_function_a();
+  myawesomelib_function_b();
+  mynotawesomelib_function_c();
+  return 0;
+}

--- a/test/e2e/src/some_file.c
+++ b/test/e2e/src/some_file.c
@@ -1,0 +1,30 @@
+// Copyright (c) 2021 Christophe Bedard
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include <stdio.h>
+
+#include "some_dir/some_header.h"
+
+void some_header_instrumented_with_file_list()
+{
+  // Using a partial path to the source file since
+  // that's the file that contains the implementation
+  printf("instrumented via include-file-list with a 'dir/file_' prefix\n");
+}

--- a/test/e2e/src/some_other_file.c
+++ b/test/e2e/src/some_other_file.c
@@ -1,4 +1,4 @@
-// Copyright (c) 2019 Christophe Bedard
+// Copyright (c) 2021 Christophe Bedard
 //
 // Permission is hereby granted, free of charge, to any person obtaining a copy
 // of this software and associated documentation files (the "Software"), to deal
@@ -19,28 +19,12 @@
 // SOFTWARE.
 
 #include <stdio.h>
-#include "other/other_file.h"
 
-void __attribute__((instrument_function)) instrumented_function()
-{
-  printf("this is instrumented\n");
-}
+#include "some_dir/some_other_header.h"
 
-void NOT_instrumented_function()
+void some_other_header_instrumented_with_file_list_and_attribute()
 {
-  printf("this is NOT instrumented\n");
-}
-
-void instrumented_with_function_list()
-{
-  printf("this can be instrumented via include-function-list\n");
-}
-
-int __attribute__((instrument_function)) main()
-{
-  instrumented_function();
-  NOT_instrumented_function();
-  instrumented_with_function_list();
-  instrumented_with_file_list();
-  return 0;
+  // Using a partial path to the source file since
+  // that's the file that contains the implementation
+  printf("instrumented via include-file-list with a 'dir/file_' prefix and with attribute\n");
 }

--- a/test/run_end-to-end_tests.sh
+++ b/test/run_end-to-end_tests.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+# Copyright (c) 2021 Christophe Bedard
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
+TEST_E2E_DIR=${SCRIPT_DIR}/e2e
+
+set -e # -x
+
+# Trace
+bash ${SCRIPT_DIR}/trace.sh ${SCRIPT_DIR}/test_end-to-end ${TEST_E2E_DIR}/trace
+
+# Extract func_entry events and write to a file
+func_entry_file=${TEST_E2E_DIR}/trace/func_entry.txt
+rm -f ${func_entry_file}
+babeltrace ${TEST_E2E_DIR}/trace | grep ':func_entry' > ${func_entry_file}
+
+echo -e ""
+
+# Assertion functions
+global_assert_result=0
+function check_function_traced_or_not() {
+  local function_name=$1
+  # 0=assert traced, 1=assert not traced
+  local assert_traced=$2
+  local assert_result=0
+  (grep "func = \"${function_name}+0\"" ${func_entry_file} 2>&1 > /dev/null) || assert_result=1
+  if [[ assert_traced -eq 0 && assert_result -eq 1 ]] ; then
+    echo -e "\tFunction not instrumented: ${function_name}"
+    global_assert_result=$(($global_assert_result + 1))
+  fi
+  if [[ assert_traced -eq 1 && assert_result -eq 0 ]] ; then
+    echo -e "\tFunction unexpectedly instrumented: ${function_name}"
+    global_assert_result=$(($global_assert_result + 1))
+  fi
+}
+function assert_function_traced() {
+  check_function_traced_or_not $1 0
+}
+function assert_function_not_traced() {
+  check_function_traced_or_not $1 1
+}
+function assert_num_traced_functions() {
+  local expected_num_traced_functions=$1
+  local num_traced_functions=$(grep -o ':func_entry' ${func_entry_file} | wc -l)
+  if [[ $num_traced_functions -ne $expected_num_traced_functions ]] ; then
+    echo -e "\tWrong number of traced functions: ${num_traced_functions}, expected ${expected_num_traced_functions}"
+    global_assert_result=$(($global_assert_result + 1))
+  fi
+}
+
+# Assert
+echo "Checking trace"
+
+assert_function_traced "main"
+assert_function_traced "instrumented_function"
+assert_function_not_traced "not_instrumented_function"
+assert_function_traced "instrumented_with_function_list"
+
+assert_function_traced "other_file_instrumented_with_file_list"
+
+assert_function_traced "some_header_instrumented_with_file_list"
+assert_function_traced "some_other_header_instrumented_with_file_list_and_attribute"
+
+assert_function_traced "myawesomelib_function_a"
+assert_function_traced "myawesomelib_function_b"
+assert_function_not_traced "mynotawesomelib_function_c"
+
+assert_num_traced_functions 8
+
+echo -e ""
+
+# Check overall result
+if [[ global_assert_result -ne 0 ]] ; then
+  echo 'End-to-end tests failed!'
+  exit 1
+fi
+echo 'End-to-end tests passed!'

--- a/test/utils/test_utils.c
+++ b/test/utils/test_utils.c
@@ -20,7 +20,7 @@
 #include "utils.h"
 
 #define TESTS_START() printf("Starting tests...\n")
-#define TESTS_END() printf("Tests done!\n")
+#define TESTS_END() printf("All tests passed!\n")
 #define TEST_START() printf("\t%s\n", __FUNCTION__)
 
 void test_strdup_()


### PR DESCRIPTION
Closes #13

This adds a more complex set of files/header to test most cases/plugin options.

End-to-end tests get run on that: the e2e test executable is traced and then the trace is checked to make sure it contains `func_entry` events for each function that is expected to be instrumented.

Signed-off-by: Christophe Bedard <bedard.christophe@gmail.com>