### PR TITLE
Add exact function matching option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,6 +51,7 @@ $(TEST_E2E_OBJ_DIR)/%.o: $(TEST_E2E_SRC_DIR)/%.c | $(TEST_E2E_OBJ_DIR) $(PLUGIN_
 		-fplugin-arg-instrument_attribute-debug \
 		-fplugin-arg-instrument_attribute-include-file-list=test/e2e/src/some_,test/e2e/include/other/other_file.h \
 		-fplugin-arg-instrument_attribute-include-function-list=instrumented_with_function_list,myawesomelib_,random_other_function_name \
+		-fplugin-arg-instrument_attribute-include-exact-function-list=exact_match_function \
 		-c $< -o $@
 -include $(TEST_E2E_OBJ:.o=.d)
 

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ This plugin allows you to instrument individual functions, by:
 * adding the `instrument_function` attribute to a function
 * giving a list of paths to files with function definitions (`-fplugin-arg-instrument_attribute-include-file-list=file,file,…`)
 * giving a list of function names (`-fplugin-arg-instrument_attribute-include-function-list=sym,sym,…`)
+* giving a list of function names for exact matching (`-fplugin-arg-instrument_attribute-include-exact-function-list=sym,sym,…`)
 
 For example, you might want to use this when you want to instrument only select functions and avoid instrumenting _everything_, since it adds a measurable overhead.
 
@@ -78,8 +79,15 @@ Similar to `gcc`'s [built-in flags](https://gcc.gnu.org/onlinedocs/gcc/Instrumen
 -fplugin-arg-instrument_attribute-include-function-list=sym,sym,…
 ```
 
-These matches are done on substrings.
+```
+-fplugin-arg-instrument_attribute-include-exact-function-list=sym,sym,…
+```
+
+These matches are done on substrings for `include-function-list` and `include-file-list`.
 If the given `file` value is a substring of a file's path, its functions will be instrumented; if the given `sym` value is a substring of a function's user-visible name, it will be instrumented.
+
+For `include-exact-function-list`, matches are done on exact function names only.
+This prevents false positives when a function name is a substring of another (e.g., `function_name` matching `function_name_extended`).
 
 ## Verbose mode and debugging
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -48,3 +48,11 @@ void free_list(struct string_list * list);
  * \return the match (const string) from the list, or NULL.
  */
 const char * list_strstr(struct string_list * list, const char * str1);
+
+/// Check if the given string exactly matches any string in the list
+/**
+ * \param list the list
+ * \param str1 the string
+ * \return the match (const string) from the list, or NULL.
+ */
+ const char * list_strcmp(struct string_list * list, const char * str1);

--- a/src/utils.c
+++ b/src/utils.c
@@ -87,3 +87,13 @@ const char * list_strstr(struct string_list * list, const char * str1)
   }
   return NULL;
 }
+
+const char * list_strcmp(struct string_list * list, const char * str1)
+{
+  for (size_t i = 0; i < list->len; i++) {
+    if (0 == strcmp(str1, list->data[i])) {
+      return list->data[i];
+    }
+  }
+  return NULL;
+}

--- a/test/e2e/src/main.c
+++ b/test/e2e/src/main.c
@@ -40,6 +40,16 @@ void instrumented_with_function_list()
   printf("instrumented via include-function-list\n");
 }
 
+void exact_match_function()
+{
+  printf("instrumented via exact function list\n");
+}
+
+void exact_match_function_ex()
+{
+  printf("should NOT be instrumented (substring match but not exact)\n");
+}
+
 int __attribute__((instrument_function)) main()
 {
   printf("instrumented with attribute\n");
@@ -56,5 +66,9 @@ int __attribute__((instrument_function)) main()
   myawesomelib_function_a();
   myawesomelib_function_b();
   mynotawesomelib_function_c();
+
+  exact_match_function();
+  exact_match_function_ex();
+
   return 0;
 }

--- a/test/run_end-to-end_tests.sh
+++ b/test/run_end-to-end_tests.sh
@@ -83,7 +83,10 @@ assert_function_traced "myawesomelib_function_a"
 assert_function_traced "myawesomelib_function_b"
 assert_function_not_traced "mynotawesomelib_function_c"
 
-assert_num_traced_functions 8
+assert_function_traced "exact_match_function"
+assert_function_not_traced "exact_match_function_ex"
+
+assert_num_traced_functions 9
 
 echo -e ""
 


### PR DESCRIPTION
- Add include-exact-function-list option for exact function name matching
- Prevents false positives from substring matching (e.g., function_name matching function_name_extended)
- Add test case for exact matching
- Update README with documentation